### PR TITLE
242# [achadosepedidos] Ajustes de interface depois da reclassificação dos atendimentos

### DIFF
--- a/src/Template/Agentes/detalhe.ctp
+++ b/src/Template/Agentes/detalhe.ctp
@@ -132,19 +132,16 @@
                <?php
                       $arrSituacaoPedido = $this->FrontEnd->statusPedido($pedido["CodigoStatusPedido"],$pedido["CodigoStatusPedidoInterno"])
                     ?>
-                    <?=$arrSituacaoPedido["imagem"];?>
-                    <?=$arrSituacaoPedido["texto"];?>
-                    <img src="<?=BASE_URL?>assets/images/pedidos/pergunta.png" alt="" data-tooltip="tooltip-resposta-pedido" class="img-responsive tooltip-ajuda-action">
-                    <div id="tooltip-resposta-pedido" class="tooltip-ajuda hidden">
-                      <div class="tooltip-ajuda-inner">
-                      Esta classificação é feita com um modelo de inteligência artificial que 
-                      analisa a estrutura dos textos do pedido e da resposta para determinar se a 
-                      solicitação foi atendida de fato, ou seja, se a informação foi fornecida. 
-                      O código, desenvolvido especialmente para o Achados e Pedidos, classifica corretamente os pedidos em 85% dos casos. 
-                      Caso encontre uma classificação incorreta, por favor nos notifique. Saiba mais                     
-                      </div>
-                      <a class="tooltip-ajuda-icon" href="<?=BASE_URL?>na-midia/achados-e-pedidos-usa-inteligencia-artificial-para-classificar-atendimento-a-pedidos">aqui</a>
+                    <div class="span2">
+                      <?=$arrSituacaoPedido["imagem"];?>
                     </div>
+                    <div  style="float:left;margin-right:4px;">                
+                    <?=$arrSituacaoPedido["texto"];?>
+                </div>
+                <div>
+                  <img src="<?=BASE_URL?>assets/images/pedidos/pergunta.png" alt="" data-tooltip="tooltip-resposta-pedido" class="img-responsive tooltip-ajuda-action" style="cursor:pointer;">
+                </div>                    
+                <?= $this->element('Pedidos/tooltip');?>
             </div>
             <div class="col-md-4 col-sm-4 col-xs-12">
               <div class="btnVerMais pull-right">

--- a/src/Template/Agentes/detalhe.ctp
+++ b/src/Template/Agentes/detalhe.ctp
@@ -134,6 +134,17 @@
                     ?>
                     <?=$arrSituacaoPedido["imagem"];?>
                     <?=$arrSituacaoPedido["texto"];?>
+                    <img src="<?=BASE_URL?>assets/images/pedidos/pergunta.png" alt="" data-tooltip="tooltip-resposta-pedido" class="img-responsive tooltip-ajuda-action">
+                    <div id="tooltip-resposta-pedido" class="tooltip-ajuda hidden">
+                      <div class="tooltip-ajuda-inner">
+                      Esta classificação é feita com um modelo de inteligência artificial que 
+                      analisa a estrutura dos textos do pedido e da resposta para determinar se a 
+                      solicitação foi atendida de fato, ou seja, se a informação foi fornecida. 
+                      O código, desenvolvido especialmente para o Achados e Pedidos, classifica corretamente os pedidos em 85% dos casos. 
+                      Caso encontre uma classificação incorreta, por favor nos notifique. Saiba mais                     
+                      </div>
+                      <a class="tooltip-ajuda-icon" href="<?=BASE_URL?>na-midia/achados-e-pedidos-usa-inteligencia-artificial-para-classificar-atendimento-a-pedidos">aqui</a>
+                    </div>
             </div>
             <div class="col-md-4 col-sm-4 col-xs-12">
               <div class="btnVerMais pull-right">
@@ -175,3 +186,4 @@
   })
 </script>
 <script type="text/javascript" src="<?=BASE_URL?>assets/js/minhaconta/interacao.js" ></script>
+<script type="text/javascript" src="<?=BASE_URL?>assets/js/tooltip-ajuda.js" ></script>

--- a/src/Template/Busca/index.ctp
+++ b/src/Template/Busca/index.ctp
@@ -86,17 +86,8 @@
                       </div>
                       <div class="col-md-6 col-sm-6 col-xs-12">
                         <?=$this->FrontEnd->statusPedido($pedido["CodigoStatusPedido"],$pedido["CodigoStatusPedidoInterno"])?>
-                        <img src="<?=BASE_URL?>assets/images/pedidos/pergunta.png" alt="" data-tooltip="tooltip-resposta-pedido" class="img-responsive tooltip-ajuda-action">
-                        <div id="tooltip-resposta-pedido" class="tooltip-ajuda hidden">
-                          <div class="tooltip-ajuda-inner">
-                          Esta classificação é feita com um modelo de inteligência artificial que 
-                          analisa a estrutura dos textos do pedido e da resposta para determinar se a 
-                          solicitação foi atendida de fato, ou seja, se a informação foi fornecida. 
-                          O código, desenvolvido especialmente para o Achados e Pedidos, classifica corretamente os pedidos em 85% dos casos. 
-                          Caso encontre uma classificação incorreta, por favor nos notifique. Saiba mais                     
-                          </div>
-                          <a class="tooltip-ajuda-icon" href="<?=BASE_URL?>na-midia/achados-e-pedidos-usa-inteligencia-artificial-para-classificar-atendimento-a-pedidos">aqui</a>
-                        </div>
+                        <img src="<?=BASE_URL?>assets/images/pedidos/pergunta.png" alt="" data-tooltip="tooltip-resposta-pedido" class="img-responsive tooltip-ajuda-action" style="cursor:pointer;">
+                        <?= $this->element('Pedidos/tooltip');?>  
                       </div>
                   </div>
                   <div class="col-md-4 col-sm-4 col-xs-12 highlight-box">

--- a/src/Template/Busca/index.ctp
+++ b/src/Template/Busca/index.ctp
@@ -77,7 +77,7 @@
                     <p class="title">
                       <?=$pedido["Titulo"]?>
                     </p>
-                    <div class="enviado">Pedido enviado para: <a href="<?=$this->Url->build('/agentes/' . $pedido["SlugAgente"])?>"><?=$pedido["NomeAgente"]?></a></div>
+                    <div class="enviado">xPedido enviado para: <a href="<?=$this->Url->build('/agentes/' . $pedido["SlugAgente"])?>"><?=$pedido["NomeAgente"]?></a></div>
                     <div class="por">Pedido disponibilizado por: <a href="<?=$this->Url->build($slugUsuario)?>"><?=$nomeUsuario?></a></div>
                     <div class="em">Em: <?=$pedido["DataEnvio"]?></div>
                     <div class="situacao">
@@ -86,8 +86,18 @@
                       </div>
                       <div class="col-md-6 col-sm-6 col-xs-12">
                         <?=$this->FrontEnd->statusPedido($pedido["CodigoStatusPedido"],$pedido["CodigoStatusPedidoInterno"])?>
+                        <img src="<?=BASE_URL?>assets/images/pedidos/pergunta.png" alt="" data-tooltip="tooltip-resposta-pedido" class="img-responsive tooltip-ajuda-action">
+                        <div id="tooltip-resposta-pedido" class="tooltip-ajuda hidden">
+                          <div class="tooltip-ajuda-inner">
+                          Esta classificação é feita com um modelo de inteligência artificial que 
+                          analisa a estrutura dos textos do pedido e da resposta para determinar se a 
+                          solicitação foi atendida de fato, ou seja, se a informação foi fornecida. 
+                          O código, desenvolvido especialmente para o Achados e Pedidos, classifica corretamente os pedidos em 85% dos casos. 
+                          Caso encontre uma classificação incorreta, por favor nos notifique. Saiba mais                     
+                          </div>
+                          <a class="tooltip-ajuda-icon" href="<?=BASE_URL?>na-midia/achados-e-pedidos-usa-inteligencia-artificial-para-classificar-atendimento-a-pedidos">aqui</a>
+                        </div>
                       </div>
-                    </div>
                   </div>
                   <div class="col-md-4 col-sm-4 col-xs-12 highlight-box">
                     <p class="highlight-session bgcolor5">Resposta do recurso - 1º Instância</p>
@@ -237,3 +247,5 @@
       });
     });
 </script>
+
+<script type="text/javascript" src="<?=BASE_URL?>assets/js/tooltip-ajuda.js" ></script>

--- a/src/Template/Element/Pedidos/tooltip.ctp
+++ b/src/Template/Element/Pedidos/tooltip.ctp
@@ -1,0 +1,12 @@
+<div id="tooltip-resposta-pedido" class="tooltip-ajuda hidden text-right">
+    <div class="text-right">
+        <a href="#" class="close-tooltip" data-dismiss="alert" style="color:white;">&times;</a>
+    </div>
+    <div class="tooltip-ajuda-inner text-left" style="padding:5px;">
+        Esta classificação é feita com um modelo de inteligência artificial que 
+        analisa a estrutura dos textos do pedido e da resposta para determinar se a 
+        solicitação foi atendida de fato, ou seja, se a informação foi fornecida. 
+        O código, desenvolvido especialmente para o Achados e Pedidos, classifica corretamente os pedidos em 85% dos casos. 
+        Caso encontre uma classificação incorreta, por favor nos notifique. Saiba mais <a class="tooltip-ajuda-icon" href="<?=BASE_URL?>na-midia/achados-e-pedidos-usa-inteligencia-artificial-para-classificar-atendimento-a-pedidos" target="_blank">aqui</a>              
+    </div>
+</div>

--- a/src/Template/Layout/front.ctp
+++ b/src/Template/Layout/front.ctp
@@ -252,7 +252,6 @@ $blipchat_key = Configure::read("BlipChat.Key");
     </div>
 
     <div class="message-bubble">
-        <p>Quer ajuda com um pedido ou recurso?</p>
         <span class="close-button" id="bubble-msg" onclick="this.parentElement.style.display='none'"></span>
     </div>
 

--- a/src/Template/Minhaconta/Home/index.ctp
+++ b/src/Template/Minhaconta/Home/index.ctp
@@ -154,19 +154,16 @@
                <?php
                       $arrSituacaoPedido = $this->FrontEnd->statusPedido($pedido["CodigoStatusPedido"],$pedido["CodigoStatusPedidoInterno"])
                     ?>
-                    <?=$arrSituacaoPedido["imagem"];?>
-                    <?=$arrSituacaoPedido["texto"];?>
-                    <img src="<?=BASE_URL?>assets/images/pedidos/pergunta.png" alt="" data-tooltip="tooltip-resposta-pedido" class="img-responsive tooltip-ajuda-action">
-                    <div id="tooltip-resposta-pedido" class="tooltip-ajuda hidden">
-                      <div class="tooltip-ajuda-inner">
-                      Esta classificação é feita com um modelo de inteligência artificial que 
-                      analisa a estrutura dos textos do pedido e da resposta para determinar se a 
-                      solicitação foi atendida de fato, ou seja, se a informação foi fornecida. 
-                      O código, desenvolvido especialmente para o Achados e Pedidos, classifica corretamente os pedidos em 85% dos casos. 
-                      Caso encontre uma classificação incorreta, por favor nos notifique. Saiba mais                     
-                      </div>
-                      <a class="tooltip-ajuda-icon" href="<?=BASE_URL?>na-midia/achados-e-pedidos-usa-inteligencia-artificial-para-classificar-atendimento-a-pedidos">aqui</a>
+                    <div class="span2">
+                      <?=$arrSituacaoPedido["imagem"];?>
                     </div>
+                    <div style="float:left;margin-right:4px;">                
+                      <?=$arrSituacaoPedido["texto"];?>
+                    </div>
+                    <div>
+                      <img src="<?=BASE_URL?>assets/images/pedidos/pergunta.png" alt="" data-tooltip="tooltip-resposta-pedido" class="img-responsive tooltip-ajuda-action" style="cursor:pointer;">
+                    </div>
+                    <?= $this->element('Pedidos/tooltip');?> 
             </div>
             <div class="col-md-4 col-sm-4 col-xs-12">
               <div class="btnVerMais pull-right">

--- a/src/Template/Minhaconta/Home/index.ctp
+++ b/src/Template/Minhaconta/Home/index.ctp
@@ -156,6 +156,17 @@
                     ?>
                     <?=$arrSituacaoPedido["imagem"];?>
                     <?=$arrSituacaoPedido["texto"];?>
+                    <img src="<?=BASE_URL?>assets/images/pedidos/pergunta.png" alt="" data-tooltip="tooltip-resposta-pedido" class="img-responsive tooltip-ajuda-action">
+                    <div id="tooltip-resposta-pedido" class="tooltip-ajuda hidden">
+                      <div class="tooltip-ajuda-inner">
+                      Esta classificação é feita com um modelo de inteligência artificial que 
+                      analisa a estrutura dos textos do pedido e da resposta para determinar se a 
+                      solicitação foi atendida de fato, ou seja, se a informação foi fornecida. 
+                      O código, desenvolvido especialmente para o Achados e Pedidos, classifica corretamente os pedidos em 85% dos casos. 
+                      Caso encontre uma classificação incorreta, por favor nos notifique. Saiba mais                     
+                      </div>
+                      <a class="tooltip-ajuda-icon" href="<?=BASE_URL?>na-midia/achados-e-pedidos-usa-inteligencia-artificial-para-classificar-atendimento-a-pedidos">aqui</a>
+                    </div>
             </div>
             <div class="col-md-4 col-sm-4 col-xs-12">
               <div class="btnVerMais pull-right">
@@ -200,3 +211,4 @@
   })
 </script>
 <script type="text/javascript" src="<?=BASE_URL?>assets/js/minhaconta/interacao.js" ></script>
+<script type="text/javascript" src="<?=BASE_URL?>assets/js/tooltip-ajuda.js" ></script>

--- a/src/Template/Pedidos/detalhe.ctp
+++ b/src/Template/Pedidos/detalhe.ctp
@@ -50,11 +50,22 @@
                 $arrStatusPedido = $this->FrontEnd->statusPedido($pedido["CodigoStatusPedido"],$pedido["CodigoStatusPedidoInterno"]);
                 echo $arrStatusPedido["imagem"];
                 ?>
-                </div>
+                </div>                
                 <ul>
                   <li>Resposta:</li>
                   <li><?=$arrStatusPedido["texto"];?></li>
+                  <li><img src="<?=BASE_URL?>assets/images/pedidos/pergunta.png" alt="" data-tooltip="tooltip-resposta-pedido" class="img-responsive tooltip-ajuda-action"></li>
                 </ul>
+                <div id="tooltip-resposta-pedido" class="tooltip-ajuda hidden">
+                    <div class="tooltip-ajuda-inner">
+                    Esta classificação é feita com um modelo de inteligência artificial que 
+                    analisa a estrutura dos textos do pedido e da resposta para determinar se a 
+                    solicitação foi atendida de fato, ou seja, se a informação foi fornecida. 
+                    O código, desenvolvido especialmente para o Achados e Pedidos, classifica corretamente os pedidos em 85% dos casos. 
+                    Caso encontre uma classificação incorreta, por favor nos notifique. Saiba mais                     
+                    </div>
+                    <a class="tooltip-ajuda-icon" href="<?=BASE_URL?>na-midia/achados-e-pedidos-usa-inteligencia-artificial-para-classificar-atendimento-a-pedidos">aqui</a>
+                </div>
               </div>
             </div>
           </div>
@@ -157,12 +168,10 @@
           </div>
       </div>
     </div>
-    <div class="col-xs-12 col-md-4">
-       <div class="column-seguidores">
-         <img src="<?=BASE_URL?>assets/images/detalhes/s-icon-user.png" alt="" class="img-responsive">
-         <div class="count-seguidores"><?=$totalSeguidores?> seguidores</div>
-         <a href="javascript:void(0);" class="btnFollow" id="btnToggleSeguir"><?=$this->FrontEnd->interacao($pedido["Codigo"], 1)?></a>
-         <span class="error" id="erro_seguir"></span>
+    <div class="col-xs-12 col-md-4">      
+       <div class="column-footer">
+         <p>Encontrou algo errado?</p>
+         <a href="#" class="btnSolicitar" data-toggle="modal" data-target="#modalRevisao">Solicitar Revisão</a>
        </div>
        <div class="column-avaliacao bgDetalhes">
          <h3>Avaliação</h3>
@@ -171,10 +180,12 @@
            <span class="count">(<?=$totalAvaliacoes?>)</span><br/>
            <span class="error"></span>
          </div>
-       </div>
-       <div class="column-footer">
-         <p>Encontrou algo errado?</p>
-         <a href="#" class="btnSolicitar" data-toggle="modal" data-target="#modalRevisao">Solicitar Revisão</a>
+       </div>       
+       <div class="column-seguidores">
+         <img src="<?=BASE_URL?>assets/images/detalhes/s-icon-user.png" alt="" class="img-responsive">
+         <div class="count-seguidores"><?=$totalSeguidores?> seguidores</div>
+         <a href="javascript:void(0);" class="btnFollow" id="btnToggleSeguir"><?=$this->FrontEnd->interacao($pedido["Codigo"], 1)?></a>
+         <span class="error" id="erro_seguir"></span>
        </div>
     </div>
     <div class="col-md-offset-1 col-md-7">
@@ -243,3 +254,4 @@
   </div>
 </div>
 <script type="text/javascript" src="<?=BASE_URL?>assets/js/minhaconta/interacao.js" ></script>
+<script type="text/javascript" src="<?=BASE_URL?>assets/js/tooltip-ajuda.js" ></script>

--- a/src/Template/Pedidos/detalhe.ctp
+++ b/src/Template/Pedidos/detalhe.ctp
@@ -50,22 +50,17 @@
                 $arrStatusPedido = $this->FrontEnd->statusPedido($pedido["CodigoStatusPedido"],$pedido["CodigoStatusPedidoInterno"]);
                 echo $arrStatusPedido["imagem"];
                 ?>
-                </div>                
-                <ul>
-                  <li>Resposta:</li>
-                  <li><?=$arrStatusPedido["texto"];?></li>
-                  <li><img src="<?=BASE_URL?>assets/images/pedidos/pergunta.png" alt="" data-tooltip="tooltip-resposta-pedido" class="img-responsive tooltip-ajuda-action"></li>
-                </ul>
-                <div id="tooltip-resposta-pedido" class="tooltip-ajuda hidden">
-                    <div class="tooltip-ajuda-inner">
-                    Esta classificação é feita com um modelo de inteligência artificial que 
-                    analisa a estrutura dos textos do pedido e da resposta para determinar se a 
-                    solicitação foi atendida de fato, ou seja, se a informação foi fornecida. 
-                    O código, desenvolvido especialmente para o Achados e Pedidos, classifica corretamente os pedidos em 85% dos casos. 
-                    Caso encontre uma classificação incorreta, por favor nos notifique. Saiba mais                     
-                    </div>
-                    <a class="tooltip-ajuda-icon" href="<?=BASE_URL?>na-midia/achados-e-pedidos-usa-inteligencia-artificial-para-classificar-atendimento-a-pedidos">aqui</a>
                 </div>
+                <div  style="float:left;margin-right:4px;">                
+                  <ul>
+                    <li>Resposta:</li>
+                    <li><?=$arrStatusPedido["texto"];?></li>
+                  </ul>
+                </div>
+                <div>
+                  <img src="<?=BASE_URL?>assets/images/pedidos/pergunta.png" alt="" data-tooltip="tooltip-resposta-pedido" class="img-responsive tooltip-ajuda-action" style="cursor:pointer;">
+                </div>
+                <?= $this->element('Pedidos/tooltip');?>                
               </div>
             </div>
           </div>

--- a/src/Template/Pedidos/index.ctp
+++ b/src/Template/Pedidos/index.ctp
@@ -434,3 +434,5 @@ function removeCampo(event) {
 
 // }
 </script>
+
+<script type="text/javascript" src="<?=BASE_URL?>assets/js/tooltip-ajuda.js" ></script>

--- a/src/Template/Pedidos/index_php.ctp
+++ b/src/Template/Pedidos/index_php.ctp
@@ -232,18 +232,9 @@
                   <?=$this->FrontEnd->statusPedido($pedido["CodigoStatusPedido"],$pedido["CodigoStatusPedidoInterno"])?>
 
                   <ul>
-                    <img src="<?=BASE_URL?>assets/images/pedidos/pergunta.png" alt="" data-tooltip="tooltip-resposta-pedido" class="img-responsive tooltip-ajuda-action">
+                    <img src="<?=BASE_URL?>assets/images/pedidos/pergunta.png" alt="" data-tooltip="tooltip-resposta-pedido" class="img-responsive tooltip-ajuda-action" style="cursor:pointer;">
                   </ul>
-                  <div id="tooltip-resposta-pedido" class="tooltip-ajuda hidden">
-                    <div class="tooltip-ajuda-inner">
-                    Esta classificação é feita com um modelo de inteligência artificial que 
-                    analisa a estrutura dos textos do pedido e da resposta para determinar se a 
-                    solicitação foi atendida de fato, ou seja, se a informação foi fornecida. 
-                    O código, desenvolvido especialmente para o Achados e Pedidos, classifica corretamente os pedidos em 85% dos casos. 
-                    Caso encontre uma classificação incorreta, por favor nos notifique. Saiba mais                     
-                    </div>
-                    <a class="tooltip-ajuda-icon" href="<?=BASE_URL?>na-midia/achados-e-pedidos-usa-inteligencia-artificial-para-classificar-atendimento-a-pedidos">aqui</a>
-                </div>
+                  <?= $this->element('Pedidos/tooltip');?>    
                 </div>
                 <div class="col-md-4 col-sm-4 col-xs-12">
                   <div class="btnVerMais pull-right">

--- a/src/Template/Pedidos/index_php.ctp
+++ b/src/Template/Pedidos/index_php.ctp
@@ -230,6 +230,20 @@
                 </div>
                 <div class="col-md-4 col-sm-4 col-xs-12">
                   <?=$this->FrontEnd->statusPedido($pedido["CodigoStatusPedido"],$pedido["CodigoStatusPedidoInterno"])?>
+
+                  <ul>
+                    <img src="<?=BASE_URL?>assets/images/pedidos/pergunta.png" alt="" data-tooltip="tooltip-resposta-pedido" class="img-responsive tooltip-ajuda-action">
+                  </ul>
+                  <div id="tooltip-resposta-pedido" class="tooltip-ajuda hidden">
+                    <div class="tooltip-ajuda-inner">
+                    Esta classificação é feita com um modelo de inteligência artificial que 
+                    analisa a estrutura dos textos do pedido e da resposta para determinar se a 
+                    solicitação foi atendida de fato, ou seja, se a informação foi fornecida. 
+                    O código, desenvolvido especialmente para o Achados e Pedidos, classifica corretamente os pedidos em 85% dos casos. 
+                    Caso encontre uma classificação incorreta, por favor nos notifique. Saiba mais                     
+                    </div>
+                    <a class="tooltip-ajuda-icon" href="<?=BASE_URL?>na-midia/achados-e-pedidos-usa-inteligencia-artificial-para-classificar-atendimento-a-pedidos">aqui</a>
+                </div>
                 </div>
                 <div class="col-md-4 col-sm-4 col-xs-12">
                   <div class="btnVerMais pull-right">
@@ -257,3 +271,4 @@
 </div>
 
 <script type="text/javascript" src="<?=BASE_URL?>assets/js/pedidos.js"></script>
+<script type="text/javascript" src="<?=BASE_URL?>assets/js/tooltip-ajuda.js" ></script>

--- a/src/Template/Usuarios/detalhe.ctp
+++ b/src/Template/Usuarios/detalhe.ctp
@@ -120,19 +120,16 @@
                    <?php
                           $arrSituacaoPedido = $this->FrontEnd->statusPedido($pedido["CodigoStatusPedido"],$pedido["CodigoStatusPedidoInterno"])
                         ?>
-                        <?=$arrSituacaoPedido["imagem"];?>
-                        <?=$arrSituacaoPedido["texto"];?>
-                        <img src="<?=BASE_URL?>assets/images/pedidos/pergunta.png" alt="" data-tooltip="tooltip-resposta-pedido" class="img-responsive tooltip-ajuda-action">
-                        <div id="tooltip-resposta-pedido" class="tooltip-ajuda hidden">
-                          <div class="tooltip-ajuda-inner">
-                          Esta classificação é feita com um modelo de inteligência artificial que 
-                          analisa a estrutura dos textos do pedido e da resposta para determinar se a 
-                          solicitação foi atendida de fato, ou seja, se a informação foi fornecida. 
-                          O código, desenvolvido especialmente para o Achados e Pedidos, classifica corretamente os pedidos em 85% dos casos. 
-                          Caso encontre uma classificação incorreta, por favor nos notifique. Saiba mais                     
-                          </div>
-                          <a class="tooltip-ajuda-icon" href="<?=BASE_URL?>na-midia/achados-e-pedidos-usa-inteligencia-artificial-para-classificar-atendimento-a-pedidos">aqui</a>
-                        </div>
+                    <div class="span2">
+                      <?=$arrSituacaoPedido["imagem"];?>
+                    </div>
+                    <div style="float:left;margin-right:4px;">                
+                      <?=$arrSituacaoPedido["texto"];?>
+                    </div>
+                    <div>
+                      <img src="<?=BASE_URL?>assets/images/pedidos/pergunta.png" alt="" data-tooltip="tooltip-resposta-pedido" class="img-responsive tooltip-ajuda-action" style="cursor:pointer;">
+                    </div>
+                    <?= $this->element('Pedidos/tooltip');?> 
                 </div>
                 <div class="col-md-4 col-sm-4 col-xs-12">
                   <div class="btnVerMais pull-right">

--- a/src/Template/Usuarios/detalhe.ctp
+++ b/src/Template/Usuarios/detalhe.ctp
@@ -122,6 +122,17 @@
                         ?>
                         <?=$arrSituacaoPedido["imagem"];?>
                         <?=$arrSituacaoPedido["texto"];?>
+                        <img src="<?=BASE_URL?>assets/images/pedidos/pergunta.png" alt="" data-tooltip="tooltip-resposta-pedido" class="img-responsive tooltip-ajuda-action">
+                        <div id="tooltip-resposta-pedido" class="tooltip-ajuda hidden">
+                          <div class="tooltip-ajuda-inner">
+                          Esta classificação é feita com um modelo de inteligência artificial que 
+                          analisa a estrutura dos textos do pedido e da resposta para determinar se a 
+                          solicitação foi atendida de fato, ou seja, se a informação foi fornecida. 
+                          O código, desenvolvido especialmente para o Achados e Pedidos, classifica corretamente os pedidos em 85% dos casos. 
+                          Caso encontre uma classificação incorreta, por favor nos notifique. Saiba mais                     
+                          </div>
+                          <a class="tooltip-ajuda-icon" href="<?=BASE_URL?>na-midia/achados-e-pedidos-usa-inteligencia-artificial-para-classificar-atendimento-a-pedidos">aqui</a>
+                        </div>
                 </div>
                 <div class="col-md-4 col-sm-4 col-xs-12">
                   <div class="btnVerMais pull-right">
@@ -163,3 +174,4 @@
   })
 </script>
 <script type="text/javascript" src="<?=BASE_URL?>assets/js/minhaconta/interacao.js" ></script>
+<script type="text/javascript" src="<?=BASE_URL?>assets/js/tooltip-ajuda.js" ></script>

--- a/src/View/Helper/FrontEndHelper.php
+++ b/src/View/Helper/FrontEndHelper.php
@@ -149,36 +149,36 @@ class FrontEndHelper extends Helper
             {
                 case 1:
                     $statusPedido["imagem"] = '<img src="'.BASE_URL.'assets/images/pedidos/icon-atendido.png" class="img-responsive" alt="Atendido (Não verificado)">';
-                    $statusPedido["texto"]  = '<strong>Atendido</strong><br>(Não verificado)'; break;
+                    $statusPedido["texto"]  = '<strong>Atendido</strong>'; break;
                 case 2:
                     $statusPedido["imagem"] = '<img src="'.BASE_URL.'assets/images/pedidos/icon-nao-atendido.png" class="img-responsive" alt="Não Atendido (Não verificado)">';
-                    $statusPedido["texto"]  = '<strong>Não Atendido</strong><br>(Não verificado)'; break;
+                    $statusPedido["texto"]  = '<strong>Não Atendido</strong>'; break;
                 case 3:
                     $statusPedido["imagem"] = '<img src="'.BASE_URL.'assets/images/pedidos/icon-parcialmente-atendido.png" class="img-responsive" alt="Parcialmente Atendido (Não verificado)">';
-                    $statusPedido["texto"]  = '<strong>Parcialmente Atendido</strong><br>(Não verificado)'; break;
+                    $statusPedido["texto"]  = '<strong>Parcialmente Atendido</strong>'; break;
                 case 4:
                     $statusPedido["imagem"] = '<img src="'.BASE_URL.'assets/images/pedidos/icon-naoclassificado.png" class="img-responsive" alt="Não Classificado">';
-                    $statusPedido["texto"]  = '<strong>Não Classificado</strong><br>(Não verificado)'; break;
+                    $statusPedido["texto"]  = '<strong>Não Classificado</strong>'; break;
             }
         } else {
             //pega da tabela pedidos.CodigoStatusPedidoInterno
             switch($codigoStatusInterno)
             {
                 case 1:
-                    $statusPedido["imagem"] = '<img src="'.BASE_URL.'assets/images/pedidos/icon-atendido-verificado.png" class="img-responsive" alt="Atendido (Status verificado)">';
-                    $statusPedido["texto"]  = '<strong>Atendido</strong><br>(Status verificado)'; break;
+                    $statusPedido["imagem"] = '<img src="'.BASE_URL.'assets/images/pedidos/icon-atendido-verificado.png" class="img-responsive" alt="Atendido">';
+                    $statusPedido["texto"]  = '<strong>Atendido</strong><br>'; break;
                 case 2:
-                    $statusPedido["imagem"] = '<img src="'.BASE_URL.'assets/images/pedidos/icon-nao-atendido-verificado.png" class="img-responsive" alt="Não Atendido (Status verificado)">';
-                    $statusPedido["texto"] = '<strong>Não Atendido</strong><br>(Status verificado)'; break;
+                    $statusPedido["imagem"] = '<img src="'.BASE_URL.'assets/images/pedidos/icon-nao-atendido-verificado.png" class="img-responsive" alt="Não Atendido">';
+                    $statusPedido["texto"] = '<strong>Não Atendido</strong><br>'; break;
                 case 3:
-                    $statusPedido["imagem"] = '<img src="'.BASE_URL.'assets/images/pedidos/icon-parcialmente-atendido-verificado.png" class="img-responsive" alt="Parcialmente Atendido (Status verificado)">';
-                    $statusPedido["texto"]  = '<strong>Parcialmente Atendido</strong><br>(Status verificado)'; break;
+                    $statusPedido["imagem"] = '<img src="'.BASE_URL.'assets/images/pedidos/icon-parcialmente-atendido-verificado.png" class="img-responsive" alt="Parcialmente Atendido">';
+                    $statusPedido["texto"]  = '<strong>Parcialmente Atendido</strong><br>'; break;
                 case 4:
                     $statusPedido["imagem"] = '<img src="'.BASE_URL.'assets/images/pedidos/icon-naoclassificado.png" class="img-responsive" alt="Não Classificado">';
-                    $statusPedido["texto"]  = '<strong>Não Classificado</strong><br>(Status verificado)'; break;
+                    $statusPedido["texto"]  = '<strong>Não Classificado</strong><br>'; break;
             }
         }
-
+        
         return $statusPedido;
     }
 

--- a/webroot/assets/js/busca.js
+++ b/webroot/assets/js/busca.js
@@ -1,13 +1,13 @@
-$(function () {
+$(function() {
 
-  $( "input[type=reset]" ).click(function() {
-      $("input#enviadoPara").prop("value","");
-      $("input#por").prop("value","");
-  });
+    $("input[type=reset]").click(function() {
+        $("input#enviadoPara").prop("value", "");
+        $("input#por").prop("value", "");
+    });
 
 
 
-    $(document).ready(function () {
+    $(document).ready(function() {
 
         //verifica URL. lista default de pedidos so entra na pagina de pedidos
         if (location.href.indexOf("/busca") <= -1) {
@@ -27,7 +27,7 @@ $(function () {
         $("#cabecalho-resultados").hide();
         $("#sem-resultados").hide();
 
-        $( "#btnsearch" ).click(function() {
+        $("#btnsearch").click(function() {
             if ($(this).attr('attr') == "busca_pedido") {
                 search_pedidos($('#fieldValue').val(), 1);
             } else {
@@ -35,12 +35,12 @@ $(function () {
             }
         });
 
-        $( "input[type=reset]" ).click(function() {
-            $(".filtro").find(":checkbox").each(function () {
+        $("input[type=reset]").click(function() {
+            $(".filtro").find(":checkbox").each(function() {
                 $(this).prop("checked", false);
             });
-            $("#data-de").prop("value","");
-            $("#data-ate").prop("value","");
+            $("#data-de").prop("value", "");
+            $("#data-ate").prop("value", "");
             if ($(".termo-display").text().length > 0) {
                 search_pedidos($(".termo-display").text(), 1);
             } else {
@@ -49,7 +49,7 @@ $(function () {
         });
 
         $(document).keypress(function(e) {
-            if(e.which == 13) {
+            if (e.which == 13) {
                 if ($("#btnsearch").attr('attr') == "busca_pedido") {
                     search_pedidos($('#fieldValue').val(), 1);
                 } else {
@@ -59,20 +59,20 @@ $(function () {
             }
         });
 
-       $(".filtro").find(":checkbox").click(function() {
-             if ($(".termo-display").text().length > 0) {
+        $(".filtro").find(":checkbox").click(function() {
+            if ($(".termo-display").text().length > 0) {
                 search_pedidos($(".termo-display").text(), 1);
-             } else {
+            } else {
                 listar_pedidos(1);
-             }
+            }
         });
 
-       $(".filtro").find(":text").change(function() {
-             if ($(".termo-display").text().length > 0) {
+        $(".filtro").find(":text").change(function() {
+            if ($(".termo-display").text().length > 0) {
                 search_pedidos($(".termo-display").text(), 1);
-             } else {
+            } else {
                 listar_pedidos(1);
-             }
+            }
         });
 
     });
@@ -86,24 +86,24 @@ $(function () {
         if (pagination.first == null) {
             $("#ulPagination").append('<li class="disabled"><span>«</span></li>');
         } else {
-            $("#ulPagination").append('<li><span><a href="#" class="paginacao" id="'+pagination.first+'">«</a></span></li>');
+            $("#ulPagination").append('<li><span><a href="#" class="paginacao" id="' + pagination.first + '">«</a></span></li>');
         }
 
         _.each(pagination.range, function(item) {
             if (item == pagination.current) {
-                $("#ulPagination").append('<li class="disabled active"><a href="#">'+ item +'</a></li>');
+                $("#ulPagination").append('<li class="disabled active"><a href="#">' + item + '</a></li>');
             } else {
-                $("#ulPagination").append('<li><a href="#" class="paginacao" id="'+item+'">'+ item +'</a></li>');
+                $("#ulPagination").append('<li><a href="#" class="paginacao" id="' + item + '">' + item + '</a></li>');
             }
         });
 
         if (pagination.last == null) {
             $("#ulPagination").append('<li class="disabled"><span>»</span></li>');
         } else {
-            $("#ulPagination").append('<li><span><a href="#" class="paginacao" id="'+pagination.last+'">»</a></span></li>');
+            $("#ulPagination").append('<li><span><a href="#" class="paginacao" id="' + pagination.last + '">»</a></span></li>');
         }
 
-        $( ".paginacao" ).click(function() {
+        $(".paginacao").click(function() {
             if ($(".termo-display").text().length > 0) {
                 if ($("#btnsearch").attr('attr') == "busca_pedido") {
                     search_pedidos($(".termo-display").text(), $(this).attr("id"));
@@ -117,7 +117,7 @@ $(function () {
 
     }
 
-   function listar_pedidos(page) {
+    function listar_pedidos(page) {
 
         var newData_de = undefined;
         if ($("#data-de").val().length > 0) {
@@ -132,31 +132,31 @@ $(function () {
         }
 
         var data = {
-            "currentPage"           : page,
-            "dataDe"                : newData_de,
-            "dataAte"               : newData_ate,
-            "chkEmTramitacao"       : $('#chkEmTramitacao').is(':checked'),
-            "chkFinalizada"         : $('#chkFinalizada').is(':checked'),
-            "chkPedidosRecursoSim"  : $('#chkPedidosRecursoSim').is(':checked'),
-            "chkPedidosRecursoNao"  : $('#chkPedidosRecursoNao').is(':checked'),
-            "chkAtendido"           : $('#chkAtendido').is(':checked'),
-            "chkNaoAtendido"        : $('#chkNaoAtendido').is(':checked'),
-            "chkParcAtendido"       : $('#chkParcAtendido').is(':checked'),
-            "chkFederal"            : $('#chkFederal').is(':checked'),
-            "chkEstadual"           : $('#chkEstadual').is(':checked'),
-            "chkMunicipal"          : $('#chkMunicipal').is(':checked'),
-            "chkLegislativo"        : $('#chkLegislativo').is(':checked'),
-            "chkExecutivo"          : $('#chkExecutivo').is(':checked'),
-            "chkJudiciario"         : $('#chkJudiciario').is(':checked'),
-            "chkMinisterio"         : $('#chkMinisterio').is(':checked')
+            "currentPage": page,
+            "dataDe": newData_de,
+            "dataAte": newData_ate,
+            "chkEmTramitacao": $('#chkEmTramitacao').is(':checked'),
+            "chkFinalizada": $('#chkFinalizada').is(':checked'),
+            "chkPedidosRecursoSim": $('#chkPedidosRecursoSim').is(':checked'),
+            "chkPedidosRecursoNao": $('#chkPedidosRecursoNao').is(':checked'),
+            "chkAtendido": $('#chkAtendido').is(':checked'),
+            "chkNaoAtendido": $('#chkNaoAtendido').is(':checked'),
+            "chkParcAtendido": $('#chkParcAtendido').is(':checked'),
+            "chkFederal": $('#chkFederal').is(':checked'),
+            "chkEstadual": $('#chkEstadual').is(':checked'),
+            "chkMunicipal": $('#chkMunicipal').is(':checked'),
+            "chkLegislativo": $('#chkLegislativo').is(':checked'),
+            "chkExecutivo": $('#chkExecutivo').is(':checked'),
+            "chkJudiciario": $('#chkJudiciario').is(':checked'),
+            "chkMinisterio": $('#chkMinisterio').is(':checked')
         };
 
-        $.ajax(es_url+'pedidos/listar', {
+        $.ajax(es_url + 'pedidos/listar', {
             method: "POST",
             data: data,
             contentType: 'application/x-www-form-urlencoded',
             dataType: "json",
-            success: function (result) {
+            success: function(result) {
                 pagination(result.pagination);
 
                 if (result.hits.hits.total > 0) {
@@ -169,12 +169,12 @@ $(function () {
                     $("#boxes-resultados").hide();
                     return;
                 }
-                $(".hits-total-display").text( result.hits.hits.total );
+                $(".hits-total-display").text(result.hits.hits.total);
 
-                $(".paginacao-de").text( result.pagination.fromResult );
-                $(".paginacao-ate").text( result.pagination.toResult );
+                $(".paginacao-de").text(result.pagination.fromResult);
+                $(".paginacao-ate").text(result.pagination.toResult);
 
-                $( "#fieldValue" ).val('');
+                $("#fieldValue").val('');
                 $("#boxes-resultados").empty();
 
                 _.each(result.hits.hits.hits, function(item) {
@@ -182,7 +182,7 @@ $(function () {
                 });
 
             },
-            error: function (err) {
+            error: function(err) {
                 console.log(err);
 
             }
@@ -198,10 +198,10 @@ $(function () {
             $("#cabecalho-resultados").css("display", "none");
             return;
         }
-        console.log (fieldValue + " ," + page);
+        console.log(fieldValue + " ," + page);
         var data = {
-            "value" :  fieldValue,
-            "currentPage" : page
+            "value": fieldValue,
+            "currentPage": page
         };
 
         $.ajax(es_url + 'consulta-simples', {
@@ -210,7 +210,7 @@ $(function () {
             contentType: 'application/x-www-form-urlencoded',
             // headers: { "x-csrf-token": ns.localStorage.get('token') },
             dataType: "json",
-            success: function (result) {
+            success: function(result) {
 
                 pagination(result.pagination);
 
@@ -223,13 +223,13 @@ $(function () {
                 }
 
 
-                $(".termo-display").text( fieldValue );
-                $(".hits-total-display").text( result.hits.hits.total );
+                $(".termo-display").text(fieldValue);
+                $(".hits-total-display").text(result.hits.hits.total);
 
-                $(".paginacao-de").text( result.pagination.fromResult );
-                $(".paginacao-ate").text( result.pagination.toResult );
+                $(".paginacao-de").text(result.pagination.fromResult);
+                $(".paginacao-ate").text(result.pagination.toResult);
 
-                $( "#fieldValue" ).val('');
+                $("#fieldValue").val('');
                 $("#boxes-resultados").empty();
                 $("#cabecalho-resultados").css("display", "none");
 
@@ -250,7 +250,7 @@ $(function () {
                 });
 
             },
-            error: function (err) {
+            error: function(err) {
                 console.log(err);
 
             }
@@ -282,24 +282,24 @@ $(function () {
         }
 
         var data = {
-            "value"                 : fieldValue,
-            "currentPage"           : page,
-            "dataDe"                : newData_de,
-            "dataAte"               : newData_ate,
-            "chkEmTramitacao"       : $('#chkEmTramitacao').is(':checked'),
-            "chkFinalizada"         : $('#chkFinalizada').is(':checked'),
-            "chkPedidosRecursoSim"  : $('#chkPedidosRecursoSim').is(':checked'),
-            "chkPedidosRecursoNao"  : $('#chkPedidosRecursoNao').is(':checked'),
-            "chkAtendido"           : $('#chkAtendido').is(':checked'),
-            "chkNaoAtendido"        : $('#chkNaoAtendido').is(':checked'),
-            "chkParcAtendido"       : $('#chkParcAtendido').is(':checked'),
-            "chkFederal"            : $('#chkFederal').is(':checked'),
-            "chkEstadual"           : $('#chkEstadual').is(':checked'),
-            "chkMunicipal"          : $('#chkMunicipal').is(':checked'),
-            "chkLegislativo"        : $('#chkLegislativo').is(':checked'),
-            "chkExecutivo"          : $('#chkExecutivo').is(':checked'),
-            "chkJudiciario"         : $('#chkJudiciario').is(':checked'),
-            "chkMinisterio"         : $('#chkMinisterio').is(':checked')
+            "value": fieldValue,
+            "currentPage": page,
+            "dataDe": newData_de,
+            "dataAte": newData_ate,
+            "chkEmTramitacao": $('#chkEmTramitacao').is(':checked'),
+            "chkFinalizada": $('#chkFinalizada').is(':checked'),
+            "chkPedidosRecursoSim": $('#chkPedidosRecursoSim').is(':checked'),
+            "chkPedidosRecursoNao": $('#chkPedidosRecursoNao').is(':checked'),
+            "chkAtendido": $('#chkAtendido').is(':checked'),
+            "chkNaoAtendido": $('#chkNaoAtendido').is(':checked'),
+            "chkParcAtendido": $('#chkParcAtendido').is(':checked'),
+            "chkFederal": $('#chkFederal').is(':checked'),
+            "chkEstadual": $('#chkEstadual').is(':checked'),
+            "chkMunicipal": $('#chkMunicipal').is(':checked'),
+            "chkLegislativo": $('#chkLegislativo').is(':checked'),
+            "chkExecutivo": $('#chkExecutivo').is(':checked'),
+            "chkJudiciario": $('#chkJudiciario').is(':checked'),
+            "chkMinisterio": $('#chkMinisterio').is(':checked')
         };
         //console.log(data);
         $.ajax(es_url + 'consultar', {
@@ -308,7 +308,7 @@ $(function () {
             contentType: 'application/x-www-form-urlencoded',
             // headers: { "x-csrf-token": ns.localStorage.get('token') },
             dataType: "json",
-            success: function (result) {
+            success: function(result) {
 
                 pagination(result.pagination);
 
@@ -317,23 +317,23 @@ $(function () {
                     $("#sem-resultados").hide();
                     $("#sem-resultados").hide();
                     $("#primeira-tela").hide();
-                 } else {
-                     $("#boxes-resultados").empty();
-                     $("#cabecalho-resultados").hide();
-                     $("#sem-resultados").show();
-                     $("termo-display-noresult").text( fieldValue )
-                     $("#primeira-tela").hide();
-                     //return;
-                 }
+                } else {
+                    $("#boxes-resultados").empty();
+                    $("#cabecalho-resultados").hide();
+                    $("#sem-resultados").show();
+                    $("termo-display-noresult").text(fieldValue)
+                    $("#primeira-tela").hide();
+                    //return;
+                }
 
-                $(".termo-display").text( fieldValue );
+                $(".termo-display").text(fieldValue);
                 //console.log(result);
-                $(".hits-total-display").text( result.hits.hits.total );
+                $(".hits-total-display").text(result.hits.hits.total);
 
-                $(".paginacao-de").text( result.pagination.fromResult );
-                $(".paginacao-ate").text( result.pagination.toResult );
+                $(".paginacao-de").text(result.pagination.fromResult);
+                $(".paginacao-ate").text(result.pagination.toResult);
 
-                $( "#fieldValue" ).val('');
+                $("#fieldValue").val('');
                 $("#boxes-resultados").empty();
 
                 _.each(result.hits.hits.hits, function(item) {
@@ -353,7 +353,7 @@ $(function () {
                 });
 
             },
-            error: function (err) {
+            error: function(err) {
 
                 console.log(err);
 
@@ -365,11 +365,11 @@ $(function () {
     }
 
     function retornaIconSituacao(value) {
-        switch(value) {
+        switch (value) {
             case "1":
-                return '<img src="'+base_url+'assets/images/pedidos/icon-em-tramitacao.png">';
+                return '<img src="' + base_url + 'assets/images/pedidos/icon-em-tramitacao.png">';
             default:
-                return '<img src="'+base_url+'assets/images/pedidos/icon-finalizado.png">';
+                return '<img src="' + base_url + 'assets/images/pedidos/icon-finalizado.png">';
         }
     }
 
@@ -379,7 +379,7 @@ $(function () {
 
         //console.log(value + " , " + value_interno)
 
-        switch(value) {
+        switch (value) {
             case "1":
                 icon = 'icon-atendido';
                 break
@@ -400,7 +400,7 @@ $(function () {
             icon += '-verificado';
         }
         //console.log('<img src="assets/images/pedidos/' + icon + '.png">');
-        return '<img src="'+base_url+'assets/images/pedidos/' + icon + '.png">';
+        return '<img src="' + base_url + 'assets/images/pedidos/' + icon + '.png">';
     }
 
     function ajustaData(data) {
@@ -415,7 +415,7 @@ $(function () {
         var obj = item._source;
         console.log(obj);
         var iconSituacao = retornaIconSituacao(obj.tipo_pedido_situacao_codigo_local);
-        var iconStatusPedido =  retornaIconStatusPedido(obj.status_pedido_codigo_local, obj.status_pedido_interno_codigo_local);
+        var iconStatusPedido = retornaIconStatusPedido(obj.status_pedido_codigo_local, obj.status_pedido_interno_codigo_local);
         var titulo = obj.pedidos_titulo_local;
         var descricao = obj.pedidos_titulo_local;
 
@@ -431,30 +431,30 @@ $(function () {
         var box = '<div class="col-md-12 col-sm-12 col-xs-12 box">';
         box += '  <div class="col-md-8 col-sm-8 col-xs-12">';
         box += '    <h4 style="margin-bottom:5%">' + titulo + '</h4>';
-        box += '    <div class="enviado">Pedido enviado para: <a href="agentes/'+obj.agentes_slug_local+'">' + obj.agentes_nome_local +'</a></div>';
-        box += '    <div class="por">Pedido disponibilizado por: <a href="usuarios/'+obj.usuarios_slug_local+'">' + obj.usuarios_nome_local + '</a></div>';
+        box += '    <div class="enviado">Pedido enviado para: <a href="agentes/' + obj.agentes_slug_local + '">' + obj.agentes_nome_local + '</a></div>';
+        box += '    <div class="por">Pedido disponibilizado por: <a href="usuarios/' + obj.usuarios_slug_local + '">' + obj.usuarios_nome_local + '</a></div>';
         box += '    <div class="em">Em: ' + ajustaData(obj.pedidos_data_envio_local) + '</div>';
         box += '    <div class="situacao">';
         box += '      <div class="col-md-6 col-sm-6 col-xs-12">';
-        box +=         iconSituacao;
+        box += iconSituacao;
         box += '        <p>Situação:<br> <strong>' + obj.tipo_pedido_situacao_nome_local + '</strong></p>';
         box += '      </div>';
         box += '      <div class="col-md-6 col-sm-6 col-xs-12">';
-        box +=          iconStatusPedido;
+        box += iconStatusPedido;
         box += '        <p>Resposta:<br> <strong>' + obj.status_pedido_nome_local + '</strong></p>';
-        box += '        <p>'+retornaStatusVerificado(obj.status_pedido_interno_codigo_local)+'</p>';
+        box += '        <p>' + retornaStatusVerificado(obj.status_pedido_interno_codigo_local) + '</p>';
         box += '      </div>';
         box += '    </div>';
         box += '  </div>';
         box += '  <div class="col-md-4 col-sm-4 col-xs-12 highlight-box">';
         box += '   <p class="highlight-session bgcolor1">Pedido</p>';
         box += '    <p class="highlight-text">';
-        box +=         descricao;
+        box += descricao;
         box += '    </p>';
         box += '  </div>';
         box += '  <div class="col-md-4 col-sm-4 col-xs-12 bt-margin">';
         box += '    <div class="btnVerMais pull-right">';
-        box += '      <a href="'+base_url+'pedidos/'+obj.pedidos_slug_local+'">Ver <div class="seta seta-direita"></div></a>';
+        box += '      <a href="' + base_url + 'pedidos/' + obj.pedidos_slug_local + '">Ver <div class="seta seta-direita"></div></a>';
         box += '    </div>';
         box += '  </div>';
         box += '</div>';
@@ -478,15 +478,11 @@ $(function () {
     }
 
     function retornaStatusVerificado(status) {
-        if (status == "1") {
-            return '<p>(Status Verificado)</p>';
-        } else {
-            return '';
-        }
+        return '';
     }
 
     function retornaTipoPedidoResposta(value) {
-        switch(value) {
+        switch (value) {
             case "1":
                 return '<p class="highlight-session bgcolor1">Resposta do órgão público</p>';
             case "2":
@@ -518,7 +514,7 @@ $(function () {
 
         var obj = item._source;
         var iconSituacao = retornaIconSituacao(obj.tipo_pedido_situacao_codigo);
-        var iconStatusPedido =  retornaIconStatusPedido(obj.status_pedido_codigo, obj.status_pedido_interno_codigo);
+        var iconStatusPedido = retornaIconStatusPedido(obj.status_pedido_codigo, obj.status_pedido_interno_codigo);
         var titulo = obj.pedidos_titulo;
         var descricao = obj.interacoes_descricao_local;
 
@@ -529,30 +525,30 @@ $(function () {
         var box = '<div class="col-md-12 col-sm-12 col-xs-12 box">';
         box += '  <div class="col-md-8 col-sm-8 col-xs-12">';
         box += '    <h4 style="margin-bottom:5%">' + titulo + '</h4>';
-        box += '    <div class="enviado">Pedido enviado para: <a href="agentes/'+obj.agentes_slug+'">' + obj.agentes_nome + '</a></div>';
-        box += '    <div class="por">Pedido disponibilizado por: <a href="usuarios/'+obj.usuarios_slug+'">' + obj.usuarios_nome + '</a></div>';
+        box += '    <div class="enviado">Pedido enviado para: <a href="agentes/' + obj.agentes_slug + '">' + obj.agentes_nome + '</a></div>';
+        box += '    <div class="por">Pedido disponibilizado por: <a href="usuarios/' + obj.usuarios_slug + '">' + obj.usuarios_nome + '</a></div>';
         box += '    <div class="em">Em: ' + ajustaData(obj.pedidos_data_envio) + '</div>';
         box += '    <div class="situacao">';
         box += '      <div class="col-md-6 col-sm-6 col-xs-12">';
-        box +=         iconSituacao;
+        box += iconSituacao;
         box += '        <p>Situação:<br> <strong>' + obj.tipo_pedido_situacao_nome + '</strong></p>';
         box += '      </div>';
         box += '      <div class="col-md-6 col-sm-6 col-xs-12">';
-        box +=          iconStatusPedido;
+        box += iconStatusPedido;
         box += '        <p>Resposta:<br> <strong>' + obj.status_pedido_nome + '</strong></p>';
-        box += '        <p>'+retornaStatusVerificado(obj.status_pedido_interno_codigo)+'</p>';
+        box += '        <p>' + retornaStatusVerificado(obj.status_pedido_interno_codigo) + '</p>';
         box += '      </div>';
         box += '    </div>';
         box += '  </div>';
         box += '  <div class="col-md-4 col-sm-4 col-xs-12 highlight-box">';
-        box +=      retornaTipoPedidoResposta(obj.tipo_pedidos_resposta_codigo_local);
+        box += retornaTipoPedidoResposta(obj.tipo_pedidos_resposta_codigo_local);
         box += '    <p class="highlight-text">';
-        box +=         descricao;
+        box += descricao;
         box += '    </p>';
         box += '  </div>';
         box += '  <div class="col-md-4 col-sm-4 col-xs-12 bt-margin">';
         box += '    <div class="btnVerMais pull-right">';
-        box += '      <a href="'+base_url+'pedidos/'+obj.pedidos_slug+'">Ver <div class="seta seta-direita"></div></a>';
+        box += '      <a href="' + base_url + 'pedidos/' + obj.pedidos_slug + '">Ver <div class="seta seta-direita"></div></a>';
         box += '    </div>';
         box += '  </div>';
         box += '</div>';
@@ -580,7 +576,7 @@ $(function () {
 
         var obj = item._source;
         var iconSituacao = retornaIconSituacao(obj.tipo_pedido_situacao_codigo);
-        var iconStatusPedido =  retornaIconStatusPedido(obj.status_pedido_codigo, obj.status_pedido_interno_codigo);
+        var iconStatusPedido = retornaIconStatusPedido(obj.status_pedido_codigo, obj.status_pedido_interno_codigo);
         var titulo = obj.pedidos_titulo;
         var descricao = obj.anexos_conteudo_arquivo;
 
@@ -592,31 +588,31 @@ $(function () {
         var box = '<div class="col-md-12 col-sm-12 col-xs-12 box">';
         box += '  <div class="col-md-8 col-sm-8 col-xs-12">';
         box += '    <h4 style="margin-bottom:5%">' + titulo + '</h4>';
-        box += '    <div class="enviado">Pedido enviado para: <a href="agentes/'+obj.agentes_slug+'">' + obj.agentes_nome + '</a></div>';
-        box += '    <div class="por">Pedido disponibilizado por: <a href="usuarios/'+obj.usuarios_slug+'">' + obj.usuarios_nome + '</a></div>';
+        box += '    <div class="enviado">Pedido enviado para: <a href="agentes/' + obj.agentes_slug + '">' + obj.agentes_nome + '</a></div>';
+        box += '    <div class="por">Pedido disponibilizado por: <a href="usuarios/' + obj.usuarios_slug + '">' + obj.usuarios_nome + '</a></div>';
         box += '    <div class="em">Em: ' + ajustaData(obj.pedidos_data_envio) + '</div>';
         box += '    <div class="situacao">';
         box += '      <div class="col-md-6 col-sm-6 col-xs-12">';
-        box +=         iconSituacao;
+        box += iconSituacao;
         box += '        <p>Situação:<br> <strong>' + obj.tipo_pedido_situacao_nome + '</strong></p>';
         box += '      </div>';
         box += '      <div class="col-md-6 col-sm-6 col-xs-12">';
-        box +=          iconStatusPedido;
+        box += iconStatusPedido;
         box += '        <p>Resposta:<br> <strong>' + obj.status_pedido_nome + '</strong></p>';
-        box += '        <p>'+retornaStatusVerificado(obj.status_pedido_interno_codigo)+'</p>';
+        box += '        <p>' + retornaStatusVerificado(obj.status_pedido_interno_codigo) + '</p>';
         box += '      </div>';
         box += '    </div>';
         box += '  </div>';
         box += '  <div class="col-md-4 col-sm-4 col-xs-12 highlight-box">';
-        box +=      retornaTipoPedidoResposta(obj.tipo_pedidos_resposta_codigo);
-        box += '    <p class="highlight-session"><a href="'+base_url + "uploads/pedidos/" + obj.anexos_arquivo + '" target="_blank"><img src="'+base_url+'assets/images/pedidos/icon-arquivo.png" style="margin-right:3px;"> arquivo anexo</a></p>';
+        box += retornaTipoPedidoResposta(obj.tipo_pedidos_resposta_codigo);
+        box += '    <p class="highlight-session"><a href="' + base_url + "uploads/pedidos/" + obj.anexos_arquivo + '" target="_blank"><img src="' + base_url + 'assets/images/pedidos/icon-arquivo.png" style="margin-right:3px;"> arquivo anexo</a></p>';
         box += '    <p class="highlight-text">';
-        box +=         descricao;
+        box += descricao;
         box += '    </p>';
         box += '  </div>';
         box += '  <div class="col-md-4 col-sm-4 col-xs-12 bt-margin">';
         box += '    <div class="btnVerMais pull-right">';
-        box += '      <a href="'+base_url+'pedidos/'+obj.pedidos_slug+'">Ver <div class="seta seta-direita"></div></a>';
+        box += '      <a href="' + base_url + 'pedidos/' + obj.pedidos_slug + '">Ver <div class="seta seta-direita"></div></a>';
         box += '    </div>';
         box += '  </div>';
         box += '</div>';
@@ -641,48 +637,46 @@ $(function () {
 
     }
 
-    function slugify(text)
-    {
+    function slugify(text) {
 
-      if (text != null) {
-        return text.toString().toLowerCase()
-            .replace(/[àáâãä]/g,"a")
-            .replace(/[éê]/g,"e")
-            .replace(/[í]/g,"i")
-            .replace(/[óôõ]/g,"o")
-            .replace(/[úü]/g,"u")
-            .replace(/[ç]/g,"c")
-            .replace(/\s+/g, '-')           // Replace spaces with -
-            .replace(/[^\w\-]+/g, '')       // Remove all non-word chars
-            .replace(/\-\-+/g, '-')        // Replace multiple - with single -
-            .replace(/^-+/, '')             // Trim - from start of text
-            .replace(/-+$/, '');            // Trim - from end of text
-    } else {
-        return null
+        if (text != null) {
+            return text.toString().toLowerCase()
+                .replace(/[àáâãä]/g, "a")
+                .replace(/[éê]/g, "e")
+                .replace(/[í]/g, "i")
+                .replace(/[óôõ]/g, "o")
+                .replace(/[úü]/g, "u")
+                .replace(/[ç]/g, "c")
+                .replace(/\s+/g, '-') // Replace spaces with -
+                .replace(/[^\w\-]+/g, '') // Remove all non-word chars
+                .replace(/\-\-+/g, '-') // Replace multiple - with single -
+                .replace(/^-+/, '') // Trim - from start of text
+                .replace(/-+$/, ''); // Trim - from end of text
+        } else {
+            return null
+        }
+
     }
 
-    }
+    function slugifyUser(text) {
 
-    function slugifyUser(text)
-    {
-
-      if (text != null) {
-          var text = text.split("@");
-          return text[0].toString().toLowerCase()
-            .replace(/[àáâãä]/g,"a")
-            .replace(/[éê]/g,"e")
-            .replace(/[í]/g,"i")
-            .replace(/[óôõ]/g,"o")
-            .replace(/[úü]/g,"u")
-            .replace(/[ç]/g,"c")
-            .replace(/\s+/g, '-')           // Replace spaces with -
-            .replace(/[^\w\-]+/g, '')       // Remove all non-word chars
-            .replace(/\-\-+/g, '-')        // Replace multiple - with single -
-            .replace(/^-+/, '')             // Trim - from start of text
-            .replace(/-+$/, '');            // Trim - from end of text
-    } else {
-        return null
-    }
+        if (text != null) {
+            var text = text.split("@");
+            return text[0].toString().toLowerCase()
+                .replace(/[àáâãä]/g, "a")
+                .replace(/[éê]/g, "e")
+                .replace(/[í]/g, "i")
+                .replace(/[óôõ]/g, "o")
+                .replace(/[úü]/g, "u")
+                .replace(/[ç]/g, "c")
+                .replace(/\s+/g, '-') // Replace spaces with -
+                .replace(/[^\w\-]+/g, '') // Remove all non-word chars
+                .replace(/\-\-+/g, '-') // Replace multiple - with single -
+                .replace(/^-+/, '') // Trim - from start of text
+                .replace(/-+$/, ''); // Trim - from end of text
+        } else {
+            return null
+        }
 
 
     }
@@ -707,20 +701,20 @@ $(function () {
 
     function autocomplete() {
 
-         $( "#fieldValue" ).keyup(function(e) {
+        $("#fieldValue").keyup(function(e) {
 
-          if (e.which != 13 && e.which != 38 && e.which != 40) {
+            if (e.which != 13 && e.which != 38 && e.which != 40) {
                 var data = {
-                    "data" :  $('#fieldValue').val()
+                    "data": $('#fieldValue').val()
                 };
 
-                $.ajax(es_url+'pedidos/searchasyoutype', {
+                $.ajax(es_url + 'pedidos/searchasyoutype', {
                     method: "POST",
                     data: data,
                     contentType: 'application/x-www-form-urlencoded',
                     // headers: { "x-csrf-token": ns.localStorage.get('token') },
                     dataType: "json",
-                    success: function (result) {
+                    success: function(result) {
 
                         console.log(result);
                         // $( "#fieldList" ).val();
@@ -728,12 +722,12 @@ $(function () {
 
                         _.each(result, function(item) {
 
-                            $( "#fieldList" ).append("<option value='"+ item +"'>");
+                            $("#fieldList").append("<option value='" + item + "'>");
 
                         });
 
                     },
-                    error: function (err) {
+                    error: function(err) {
                         console.log(err);
                     }
 

--- a/webroot/assets/js/busca_avancada.js
+++ b/webroot/assets/js/busca_avancada.js
@@ -558,20 +558,28 @@ function montaBoxPedido(item) {
     box += '    <div class="em">Em: ' + ajustaData(obj.pedidos_data_envio_local) + '</div>';
     box += '    <div class="situacao">';
     box += '      <div class="col-md-6 col-sm-6 col-xs-12">';
-    box += iconStatusPedido;
-    box += '        <p>Resposta:<br> <strong>' + obj.status_pedido_nome_local + '</strong></p>';
-    box += '        <p>' + retornaStatusVerificado(obj.status_pedido_interno_codigo_local) + '</p>';
-    box += '        <p><img src="' + base_url + 'assets/images/pedidos/pergunta.png" alt="" data-tooltip="tooltip-resposta-pedido" class="img-responsive tooltip-ajuda-action"> ';
-    box += '            <div id="tooltip-resposta-pedido" class="tooltip-ajuda hidden">';
-    box += '               <div class="tooltip-ajuda-inner">';
-    box += '                Esta classificação é feita com um modelo de inteligência artificial que ';
-    box += '                analisa a estrutura dos textos do pedido e da resposta para determinar se a ';
-    box += '                solicitação foi atendida de fato, ou seja, se a informação foi fornecida. ';
-    box += '                 O código, desenvolvido especialmente para o Achados e Pedidos, classifica corretamente os pedidos em 85% dos casos. ';
-    box += '                 Caso encontre uma classificação incorreta, por favor nos notifique. Saiba mais                     ';
-    box += '                </div>';
-    box += '                 <a class="tooltip-ajuda-icon" href="' + base_url + 'na-midia/achados-e-pedidos-usa-inteligencia-artificial-para-classificar-atendimento-a-pedidos">aqui</a>';
-    box += '            </div></p>';
+    box +=          iconStatusPedido;
+    box += '        <div  style="float:left;margin-right:15px;">';
+    box += '            <ul style="list-style-type: none;padding:0px;">'
+    box += '                <li>Resposta:</li>'
+    box += '                <li> <strong>' + obj.status_pedido_nome_local + '</strong></li>'
+    box += '            </ul>'
+    box += '        </div>'
+    box += '      <div>'
+    box += '      <img src="' + base_url + 'assets/images/pedidos/pergunta.png" alt="" data-tooltip="tooltip-resposta-pedido" class="img-responsive tooltip-ajuda-action" style="cursor:pointer;">'
+    box += '    </div>'
+    box += '    <div id="tooltip-resposta-pedido" class="tooltip-ajuda hidden text-right">';
+    box += '        <div class="text-right">';
+    box += '            <a href="#" class="close-tooltip" data-dismiss="alert" style="color:white;">&times;</a>';
+    box += '        </div>';
+    box += '        <div class="tooltip-ajuda-inner text-left" style="padding:5px;">';
+    box += '            Esta classificação é feita com um modelo de inteligência artificial que ';
+    box += '            analisa a estrutura dos textos do pedido e da resposta para determinar se a ';
+    box += '            solicitação foi atendida de fato, ou seja, se a informação foi fornecida. ';
+    box += '            O código, desenvolvido especialmente para o Achados e Pedidos, classifica corretamente os pedidos em 85% dos casos. ';
+    box += '            Caso encontre uma classificação incorreta, por favor nos notifique. Saiba mais <a class="tooltip-ajuda-icon" href="' + base_url + 'na-midia/achados-e-pedidos-usa-inteligencia-artificial-para-classificar-atendimento-a-pedidos">aqui</a>';
+    box += '      </div>';
+    box += '</div></p>';
     box += '      </div>';
     box += '    </div>';
     box += '  </div>';
@@ -613,20 +621,28 @@ function montaBoxInteracao(item) {
     box += '    <div class="em">Em: ' + ajustaData(obj.pedidos_data_envio) + '</div>';
     box += '    <div class="situacao">';
     box += '      <div class="col-md-6 col-sm-6 col-xs-12">';
-    box += iconStatusPedido;
-    box += '        <p>Resposta:<br> <strong>' + obj.status_pedido_nome + '</strong></p>';
-    box += '        <p>' + retornaStatusVerificado(obj.status_pedido_interno_codigo) + '</p>';
-    box += '        <p><img src="' + base_url + 'assets/images/pedidos/pergunta.png" alt="" data-tooltip="tooltip-resposta-pedido" class="img-responsive tooltip-ajuda-action"> ';
-    box += '            <div id="tooltip-resposta-pedido" class="tooltip-ajuda hidden">';
-    box += '               <div class="tooltip-ajuda-inner">';
-    box += '                Esta classificação é feita com um modelo de inteligência artificial que ';
-    box += '                analisa a estrutura dos textos do pedido e da resposta para determinar se a ';
-    box += '                solicitação foi atendida de fato, ou seja, se a informação foi fornecida. ';
-    box += '                 O código, desenvolvido especialmente para o Achados e Pedidos, classifica corretamente os pedidos em 85% dos casos. ';
-    box += '                 Caso encontre uma classificação incorreta, por favor nos notifique. Saiba mais                     ';
-    box += '                </div>';
-    box += '                 <a class="tooltip-ajuda-icon" href="' + base_url + 'na-midia/achados-e-pedidos-usa-inteligencia-artificial-para-classificar-atendimento-a-pedidos">aqui</a>';
-    box += '            </div></p>';
+    box +=          iconStatusPedido;
+    box += '        <div  style="float:left;margin-right:15px;">';
+    box += '            <ul style="list-style-type: none;padding:0px;">'
+    box += '                <li>Resposta:</li>'
+    box += '                <li> <strong>' + obj.status_pedido_nome + '</strong></li>'
+    box += '            </ul>'
+    box += '        </div>'
+    box += '      <div>'
+    box += '      <img src="' + base_url + 'assets/images/pedidos/pergunta.png" alt="" data-tooltip="tooltip-resposta-pedido" class="img-responsive tooltip-ajuda-action" style="cursor:pointer;">'
+    box += '    </div>'
+    box += '    <div id="tooltip-resposta-pedido" class="tooltip-ajuda hidden text-right">';
+    box += '        <div class="text-right">';
+    box += '            <a href="#" class="close-tooltip" data-dismiss="alert" style="color:white;">&times;</a>';
+    box += '        </div>';
+    box += '        <div class="tooltip-ajuda-inner text-left" style="padding:5px;">';
+    box += '            Esta classificação é feita com um modelo de inteligência artificial que ';
+    box += '            analisa a estrutura dos textos do pedido e da resposta para determinar se a ';
+    box += '            solicitação foi atendida de fato, ou seja, se a informação foi fornecida. ';
+    box += '            O código, desenvolvido especialmente para o Achados e Pedidos, classifica corretamente os pedidos em 85% dos casos. ';
+    box += '            Caso encontre uma classificação incorreta, por favor nos notifique. Saiba mais <a class="tooltip-ajuda-icon" href="' + base_url + 'na-midia/achados-e-pedidos-usa-inteligencia-artificial-para-classificar-atendimento-a-pedidos">aqui</a>';
+    box += '      </div>';
+    box += '</div></p>';
     box += '      </div>';
     box += '    </div>';
     box += '  </div>';
@@ -668,20 +684,28 @@ function montaBoxAnexo(item) {
     box += '    <div class="em">Em: ' + ajustaData(obj.pedidos_data_envio) + '</div>';
     box += '    <div class="situacao">';
     box += '      <div class="col-md-6 col-sm-6 col-xs-12">';
-    box += iconStatusPedido;
-    box += '        <p>Resposta:<br> <strong>' + obj.status_pedido_nome + '</strong></p>';
-    box += '        <p>' + retornaStatusVerificado(obj.status_pedido_interno_codigo) + '</p>';
-    box += '        <p><img src="' + base_url + 'assets/images/pedidos/pergunta.png" alt="" data-tooltip="tooltip-resposta-pedido" class="img-responsive tooltip-ajuda-action"> ';
-    box += '            <div id="tooltip-resposta-pedido" class="tooltip-ajuda hidden">';
-    box += '               <div class="tooltip-ajuda-inner">';
-    box += '                Esta classificação é feita com um modelo de inteligência artificial que ';
-    box += '                analisa a estrutura dos textos do pedido e da resposta para determinar se a ';
-    box += '                solicitação foi atendida de fato, ou seja, se a informação foi fornecida. ';
-    box += '                 O código, desenvolvido especialmente para o Achados e Pedidos, classifica corretamente os pedidos em 85% dos casos. ';
-    box += '                 Caso encontre uma classificação incorreta, por favor nos notifique. Saiba mais                     ';
-    box += '                </div>';
-    box += '                 <a class="tooltip-ajuda-icon" href="' + base_url + 'na-midia/achados-e-pedidos-usa-inteligencia-artificial-para-classificar-atendimento-a-pedidos">aqui</a>';
-    box += '            </div></p>';
+    box +=          iconStatusPedido;
+    box += '        <div  style="float:left;margin-right:15px;">';
+    box += '            <ul style="list-style-type: none;padding:0px;">'
+    box += '                <li>Resposta:</li>'
+    box += '                <li> <strong>' + obj.status_pedido_nome + '</strong></li>'
+    box += '            </ul>'
+    box += '        </div>'
+    box += '      <div>'
+    box += '      <img src="' + base_url + 'assets/images/pedidos/pergunta.png" alt="" data-tooltip="tooltip-resposta-pedido" class="img-responsive tooltip-ajuda-action" style="cursor:pointer;">'
+    box += '    </div>'
+    box += '    <div id="tooltip-resposta-pedido" class="tooltip-ajuda hidden text-right">';
+    box += '        <div class="text-right">';
+    box += '            <a href="#" class="close-tooltip" data-dismiss="alert" style="color:white;">&times;</a>';
+    box += '        </div>';
+    box += '        <div class="tooltip-ajuda-inner text-left" style="padding:5px;">';
+    box += '            Esta classificação é feita com um modelo de inteligência artificial que ';
+    box += '            analisa a estrutura dos textos do pedido e da resposta para determinar se a ';
+    box += '            solicitação foi atendida de fato, ou seja, se a informação foi fornecida. ';
+    box += '            O código, desenvolvido especialmente para o Achados e Pedidos, classifica corretamente os pedidos em 85% dos casos. ';
+    box += '            Caso encontre uma classificação incorreta, por favor nos notifique. Saiba mais <a class="tooltip-ajuda-icon" href="' + base_url + 'na-midia/achados-e-pedidos-usa-inteligencia-artificial-para-classificar-atendimento-a-pedidos">aqui</a>';
+    box += '      </div>';
+    box += '</div></p>';
     box += '      </div>';
     box += '    </div>';
     box += '  </div>';

--- a/webroot/assets/js/busca_avancada.js
+++ b/webroot/assets/js/busca_avancada.js
@@ -163,7 +163,7 @@ var scopeSearch = ['pedidos', 'interacoes', 'anexos'];
 var scopeSearchOnlyPedidos = ['pedidos'];
 
 //INICIALIZAÇÃO
-$(document).ready(function () {
+$(document).ready(function() {
 
     if (location.href.indexOf("?buscaFixa") > -1) {
         querystring = location.href.split("?");
@@ -181,8 +181,8 @@ $(document).ready(function () {
         container: 'body'
     });
 
-    var nativedatalist = !!('list' in document.createElement('input')) && 
-    !!(document.createElement('datalist') && window.HTMLDataListElement);
+    var nativedatalist = !!('list' in document.createElement('input')) &&
+        !!(document.createElement('datalist') && window.HTMLDataListElement);
 
     if (!nativedatalist) {
         // $('input[list]').each(function () {
@@ -205,15 +205,15 @@ $(document).ready(function () {
 /*
 /***********************************************************************************************************************************/
 
-btnBuscaAvancada.click(function () {
+btnBuscaAvancada.click(function() {
     search_pedidos(1);
 });
 
-btnLimpar.click(function () {
+btnLimpar.click(function() {
     limparBusca();
 });
 
-$(inputBuscaAvancada).keypress(function (e) {
+$(inputBuscaAvancada).keypress(function(e) {
     if (e.which == 13) {
         search_pedidos(1);
         e.preventDefault();
@@ -221,21 +221,21 @@ $(inputBuscaAvancada).keypress(function (e) {
     }
 });
 
-filtroCheckbox.click(function () {
+filtroCheckbox.click(function() {
     temfiltro = true;
     search_pedidos(1);
 });
 
-filtroText.change(function () {
+filtroText.change(function() {
     temfiltro = true;
     search_pedidos(1);
 });
 
-inputFiltroOrgao.click(function () {
+inputFiltroOrgao.click(function() {
     temfiltro = true;
     var show_remove_link = false;
     var counter = 1;
-    $(".enviado-para").map(function () {
+    $(".enviado-para").map(function() {
         // console.log($(thisBtn).parent.attr("id"));
         if (counter == 1) {
             if ($(this).val().trim().length > 0) {
@@ -247,7 +247,7 @@ inputFiltroOrgao.click(function () {
     search_pedidos(1);
 });
 
-inputFiltroPor.click(function () {
+inputFiltroPor.click(function() {
     temfiltro = true;
     search_pedidos(1);
 });
@@ -267,6 +267,7 @@ var parametros_visualizacao = {
     "paginacao_ate": 0,
     "palavra_chave": null,
 }
+
 function visualizacoes(_parametros) {
     var param = _parametros;
 
@@ -294,7 +295,7 @@ function visualizacoes(_parametros) {
         filtro_erro = true;
     }
 
-    $('.enviado-para').map(function () {
+    $('.enviado-para').map(function() {
         if ($(this).val().trim().length > 0) {
             filtro_erro = true;
         }
@@ -356,7 +357,7 @@ function getData(page) {
     }
 
     var enviadoPara = []
-    $('.enviado-para').map(function () {
+    $('.enviado-para').map(function() {
         if ($(this).val().trim()) {
             enviadoPara.push($(this).val().trim());
             temfiltro = true;
@@ -380,7 +381,7 @@ function getData(page) {
     if (disponibilizado_por.val() != undefined && disponibilizado_por.val().length > 0) {
         temfiltro = true;
     }
-    
+
     var data = {
         "value": fieldValue,
         "currentPage": page,
@@ -403,9 +404,9 @@ function getData(page) {
         "chkExecutivo": $('#chkExecutivo').is(':checked'),
         "chkJudiciario": $('#chkJudiciario').is(':checked'),
         "chkMinisterio": $('#chkMinisterio').is(':checked'),
-        "scope_search":setAPIScope()
+        "scope_search": setAPIScope()
     };
-    
+
     return data;
 }
 
@@ -447,49 +448,49 @@ function getData(page) {
 function search_pedidos(page) {
 
     data = getData(page);
-    
+
     //if (data.value != undefined || (data.por.length > 0 || data.enviadoPara.length > 0)) {
     //if (data.value != undefined || temfiltro === true) {
-        $.ajax(es_url + 'busca-avancada', {
-            method: "POST",
-            data: data,
-            contentType: 'application/x-www-form-urlencoded',
-            // headers: { "x-csrf-token": ns.localStorage.get('token') },
-            dataType: "json",
-            success: function (result) {
+    $.ajax(es_url + 'busca-avancada', {
+        method: "POST",
+        data: data,
+        contentType: 'application/x-www-form-urlencoded',
+        // headers: { "x-csrf-token": ns.localStorage.get('token') },
+        dataType: "json",
+        success: function(result) {
 
-                pagination(result.pagination);
+            pagination(result.pagination);
 
-                parametros_visualizacao = {
-                    "total_registros": result.hits.hits.total,
-                    "paginacao_de": result.pagination.fromResult,
-                    "paginacao_ate": result.pagination.toResult,
-                    "palavra_chave": data.value
-                }
-                visualizacoes(parametros_visualizacao)
-
-                _.each(result.hits.hits.hits, function (item) {
-                    switch (item._index) {
-                        case "pedidos":
-                            montaBoxPedido(item);
-                            break;
-                        case "interacoes":
-                            montaBoxInteracao(item);
-                            break;
-                        case "anexos":
-                            montaBoxAnexo(item);
-                            break;
-                    }
-                });
-            },
-            error: function (err) {
-
-                console.log(err);
-
+            parametros_visualizacao = {
+                "total_registros": result.hits.hits.total,
+                "paginacao_de": result.pagination.fromResult,
+                "paginacao_ate": result.pagination.toResult,
+                "palavra_chave": data.value
             }
+            visualizacoes(parametros_visualizacao)
+
+            _.each(result.hits.hits.hits, function(item) {
+                switch (item._index) {
+                    case "pedidos":
+                        montaBoxPedido(item);
+                        break;
+                    case "interacoes":
+                        montaBoxInteracao(item);
+                        break;
+                    case "anexos":
+                        montaBoxAnexo(item);
+                        break;
+                }
+            });
+        },
+        error: function(err) {
+
+            console.log(err);
+
+        }
 
 
-        });
+    });
     //}
 }
 
@@ -505,7 +506,7 @@ function pagination(pagination) {
         ulPagination.append('<li><span><a href="#" class="paginacao" id="' + pagination.first + '">«</a></span></li>');
     }
 
-    _.each(pagination.range, function (item) {
+    _.each(pagination.range, function(item) {
         if (item == pagination.current) {
             ulPagination.append('<li class="disabled active"><a href="#">' + item + '</a></li>');
         } else {
@@ -520,7 +521,7 @@ function pagination(pagination) {
     }
 
     var paginacaoClass = $(".paginacao");
-    paginacaoClass.click(function () {
+    paginacaoClass.click(function() {
         search_pedidos($(this).attr("id"));
     });
 
@@ -560,13 +561,24 @@ function montaBoxPedido(item) {
     box += iconStatusPedido;
     box += '        <p>Resposta:<br> <strong>' + obj.status_pedido_nome_local + '</strong></p>';
     box += '        <p>' + retornaStatusVerificado(obj.status_pedido_interno_codigo_local) + '</p>';
+    box += '        <p><img src="' + base_url + 'assets/images/pedidos/pergunta.png" alt="" data-tooltip="tooltip-resposta-pedido" class="img-responsive tooltip-ajuda-action"> ';
+    box += '            <div id="tooltip-resposta-pedido" class="tooltip-ajuda hidden">';
+    box += '               <div class="tooltip-ajuda-inner">';
+    box += '                Esta classificação é feita com um modelo de inteligência artificial que ';
+    box += '                analisa a estrutura dos textos do pedido e da resposta para determinar se a ';
+    box += '                solicitação foi atendida de fato, ou seja, se a informação foi fornecida. ';
+    box += '                 O código, desenvolvido especialmente para o Achados e Pedidos, classifica corretamente os pedidos em 85% dos casos. ';
+    box += '                 Caso encontre uma classificação incorreta, por favor nos notifique. Saiba mais                     ';
+    box += '                </div>';
+    box += '                 <a class="tooltip-ajuda-icon" href="' + base_url + 'na-midia/achados-e-pedidos-usa-inteligencia-artificial-para-classificar-atendimento-a-pedidos">aqui</a>';
+    box += '            </div></p>';
     box += '      </div>';
     box += '    </div>';
     box += '  </div>';
     box += '  <div class="col-md-4 col-sm-4 col-xs-12 highlight-box">';
     box += '   <p class="highlight-session bgcolor1">Pedido</p>';
     box += '    <p class="highlight-text">';
-    box +=          truncate.apply(descricao, [300, true]);
+    box += truncate.apply(descricao, [300, true]);
     box += '    </p>';
     box += '  </div>';
     box += '  <div class="col-md-4 col-sm-4 col-xs-12 bt-margin">';
@@ -578,7 +590,7 @@ function montaBoxPedido(item) {
 
 
     boxe_dos_resultados.append(box);
-
+    InitTooltipsAjuda();
 }
 
 function montaBoxInteracao(item) {
@@ -604,13 +616,24 @@ function montaBoxInteracao(item) {
     box += iconStatusPedido;
     box += '        <p>Resposta:<br> <strong>' + obj.status_pedido_nome + '</strong></p>';
     box += '        <p>' + retornaStatusVerificado(obj.status_pedido_interno_codigo) + '</p>';
+    box += '        <p><img src="' + base_url + 'assets/images/pedidos/pergunta.png" alt="" data-tooltip="tooltip-resposta-pedido" class="img-responsive tooltip-ajuda-action"> ';
+    box += '            <div id="tooltip-resposta-pedido" class="tooltip-ajuda hidden">';
+    box += '               <div class="tooltip-ajuda-inner">';
+    box += '                Esta classificação é feita com um modelo de inteligência artificial que ';
+    box += '                analisa a estrutura dos textos do pedido e da resposta para determinar se a ';
+    box += '                solicitação foi atendida de fato, ou seja, se a informação foi fornecida. ';
+    box += '                 O código, desenvolvido especialmente para o Achados e Pedidos, classifica corretamente os pedidos em 85% dos casos. ';
+    box += '                 Caso encontre uma classificação incorreta, por favor nos notifique. Saiba mais                     ';
+    box += '                </div>';
+    box += '                 <a class="tooltip-ajuda-icon" href="' + base_url + 'na-midia/achados-e-pedidos-usa-inteligencia-artificial-para-classificar-atendimento-a-pedidos">aqui</a>';
+    box += '            </div></p>';
     box += '      </div>';
     box += '    </div>';
     box += '  </div>';
     box += '  <div class="col-md-4 col-sm-4 col-xs-12 highlight-box">';
     box += retornaTipoPedidoResposta(obj.tipo_pedidos_resposta_codigo_local);
     box += '    <p class="highlight-text">';
-    box +=          truncate.apply(descricao, [300, true]);
+    box += truncate.apply(descricao, [300, true]);
     box += '    </p>';
     box += '  </div>';
     box += '  <div class="col-md-4 col-sm-4 col-xs-12 bt-margin">';
@@ -621,7 +644,7 @@ function montaBoxInteracao(item) {
     box += '</div>';
 
     boxe_dos_resultados.append(box);
-
+    InitTooltipsAjuda();
 }
 
 function montaBoxAnexo(item) {
@@ -648,6 +671,17 @@ function montaBoxAnexo(item) {
     box += iconStatusPedido;
     box += '        <p>Resposta:<br> <strong>' + obj.status_pedido_nome + '</strong></p>';
     box += '        <p>' + retornaStatusVerificado(obj.status_pedido_interno_codigo) + '</p>';
+    box += '        <p><img src="' + base_url + 'assets/images/pedidos/pergunta.png" alt="" data-tooltip="tooltip-resposta-pedido" class="img-responsive tooltip-ajuda-action"> ';
+    box += '            <div id="tooltip-resposta-pedido" class="tooltip-ajuda hidden">';
+    box += '               <div class="tooltip-ajuda-inner">';
+    box += '                Esta classificação é feita com um modelo de inteligência artificial que ';
+    box += '                analisa a estrutura dos textos do pedido e da resposta para determinar se a ';
+    box += '                solicitação foi atendida de fato, ou seja, se a informação foi fornecida. ';
+    box += '                 O código, desenvolvido especialmente para o Achados e Pedidos, classifica corretamente os pedidos em 85% dos casos. ';
+    box += '                 Caso encontre uma classificação incorreta, por favor nos notifique. Saiba mais                     ';
+    box += '                </div>';
+    box += '                 <a class="tooltip-ajuda-icon" href="' + base_url + 'na-midia/achados-e-pedidos-usa-inteligencia-artificial-para-classificar-atendimento-a-pedidos">aqui</a>';
+    box += '            </div></p>';
     box += '      </div>';
     box += '    </div>';
     box += '  </div>';
@@ -655,7 +689,7 @@ function montaBoxAnexo(item) {
     box += retornaTipoPedidoResposta(obj.tipo_pedidos_resposta_codigo);
     box += '    <p class="highlight-session"><a href="' + base_url + "uploads/pedidos/" + obj.anexos_arquivo + '" target="_blank"><img src="' + base_url + 'assets/images/pedidos/icon-arquivo.png" style="margin-right:3px;"> arquivo anexo</a></p>';
     box += '    <p class="highlight-text">';
-    box +=          truncate.apply(descricao, [300, true]);
+    box += truncate.apply(descricao, [300, true]);
     box += '    </p>';
     box += '  </div>';
     box += '  <div class="col-md-4 col-sm-4 col-xs-12 bt-margin">';
@@ -666,7 +700,7 @@ function montaBoxAnexo(item) {
     box += '</div>';
 
     boxe_dos_resultados.append(box);
-
+    InitTooltipsAjuda();
 }
 
 function retornaIconSituacao(value) {
@@ -679,11 +713,7 @@ function retornaIconSituacao(value) {
 }
 
 function retornaStatusVerificado(status) {
-    if (status == "1") {
-        return '<p>(Status Verificado)</p>';
-    } else {
-        return '';
-    }
+    return '';
 }
 
 function retornaTipoPedidoResposta(value) {
@@ -755,7 +785,7 @@ function ajustaData(data) {
 
 function autocomplete() {
 
-    inputBuscaAvancada.keyup(function (e) {
+    inputBuscaAvancada.keyup(function(e) {
 
         if (e.which != 13 && e.which != 38 && e.which != 40) {
             var data = {
@@ -768,7 +798,7 @@ function autocomplete() {
                 contentType: 'application/x-www-form-urlencoded',
                 // headers: { "x-csrf-token": ns.localStorage.get('token') },
                 dataType: "json",
-                success: function (result) {
+                success: function(result) {
 
                     // console.log(result);
                     // $( "#fieldList" ).val();
@@ -780,18 +810,18 @@ function autocomplete() {
 
                     // });
 
-                    $("#buscaAvancada").autocomplete({ 
-                        source:result,
-                        minLength:1,
-                        delay:500,
-                        autoFocus:true,
+                    $("#buscaAvancada").autocomplete({
+                        source: result,
+                        minLength: 1,
+                        delay: 500,
+                        autoFocus: true,
                         classes: {
                             "ui-autocomplete": "highlight"
-                            }
+                        }
                     });
 
                 },
-                error: function (err) {
+                error: function(err) {
                     console.log(err);
                 }
 
@@ -814,30 +844,30 @@ function autocompleteEnviadoPara(event) {
 
     console.log("autocompleteEnviadoPara")
     var data = { "data": $(event.target).val() };
-    
+
     $.ajax(es_url + 'pedidos/searchasyoutype-enviadopara', {
         method: "POST",
         data: data,
         contentType: 'application/x-www-form-urlencoded',
         dataType: "json",
-        success: function (result) {
+        success: function(result) {
             //fieldListEnviadoPara.empty();
             //console.log(result);
             // // _.each(result, function (item) {
             // //    fieldListEnviadoPara.append("<option value='" + item + "'>");
             // // });
             // console.log($(event.target));
-            $(event.target).autocomplete({ 
-                source:result,
-                minLength:2,
-                delay:500,
-                autoFocus:true,
+            $(event.target).autocomplete({
+                source: result,
+                minLength: 2,
+                delay: 500,
+                autoFocus: true,
                 classes: {
                     "ui-autocomplete": "highlight"
-                  }
+                }
             });
         },
-        error: function (err) {
+        error: function(err) {
             console.log(err);
         }
     });
@@ -845,7 +875,7 @@ function autocompleteEnviadoPara(event) {
 
 function autocompletePor() {
 
-    disponibilizado_por.keyup(function (e) {
+    disponibilizado_por.keyup(function(e) {
         var data = { "data": disponibilizado_por.val() };
 
         $.ajax(es_url + 'pedidos/searchasyoutype-por', {
@@ -853,22 +883,22 @@ function autocompletePor() {
             data: data,
             contentType: 'application/x-www-form-urlencoded',
             dataType: "json",
-            success: function (result) {
+            success: function(result) {
                 // fieldListPor.empty();
                 // _.each(result, function (item) {
                 //     fieldListPor.append("<option value='" + item + "'>");
                 // });
-                $('#por').autocomplete({ 
-                    source:result,
-                    minLength:2,
-                    delay:500,
-                    autoFocus:true,
+                $('#por').autocomplete({
+                    source: result,
+                    minLength: 2,
+                    delay: 500,
+                    autoFocus: true,
                     classes: {
                         "ui-autocomplete": "highlight"
-                      }
+                    }
                 });
             },
-            error: function (err) {
+            error: function(err) {
                 console.log(err);
             }
         });
@@ -881,8 +911,8 @@ function limparBusca() {
     console.log($(".env-container input"));
     $(".env-container input").val('');
     inputPor.prop("value", "");
-    
-    filtroCheckbox.each(function () {
+
+    filtroCheckbox.each(function() {
         $(this).prop("checked", false);
     });
     temfiltro = false;
@@ -900,10 +930,10 @@ function setAPIScope() {
     }
 }
 
-function truncate( n, useWordBoundary ){
+function truncate(n, useWordBoundary) {
     if (this.length <= n) { return this; }
-    var subString = this.substr(0, n-1);
-    return (useWordBoundary 
-       ? subString.substr(0, subString.lastIndexOf(' ')) 
-       : subString) + "...";
+    var subString = this.substr(0, n - 1);
+    return (useWordBoundary ?
+        subString.substr(0, subString.lastIndexOf(' ')) :
+        subString) + "...";
 };

--- a/webroot/assets/js/tooltip-ajuda.js
+++ b/webroot/assets/js/tooltip-ajuda.js
@@ -1,5 +1,15 @@
 $(document).ready(function() {
     InitTooltipsAjuda();
+
+    var tooltip = '';
+    $('.tooltip-ajuda-action').click(function() {
+        tooltip = $(this);
+        tooltip.tooltip('toggle');
+    })
+
+    $(document).on("click", ".close-tooltip" , function(){
+        tooltip.tooltip('hide');
+    });    
 });
 
 function InitTooltipsAjuda() {
@@ -13,7 +23,8 @@ function InitTooltipsAjuda() {
             },
             placement: 'right',
             boundary: 'window',
-            container: 'body'
+            container: 'body',
+            trigger: "manual"
         });
     });
 }

--- a/webroot/assets/js/tooltip-ajuda.js
+++ b/webroot/assets/js/tooltip-ajuda.js
@@ -2,7 +2,7 @@ $(document).ready(function() {
     InitTooltipsAjuda();
 
     var tooltip = '';
-    $('.tooltip-ajuda-action').click(function() {
+    $(document).on("click", ".tooltip-ajuda-action" , function(){
         tooltip = $(this);
         tooltip.tooltip('toggle');
     })

--- a/webroot/assets/js/tooltip-ajuda.js
+++ b/webroot/assets/js/tooltip-ajuda.js
@@ -1,0 +1,19 @@
+$(document).ready(function() {
+    InitTooltipsAjuda();
+});
+
+function InitTooltipsAjuda() {
+    // Tooltips
+    $('.tooltip-ajuda-action').each(function() {
+        $(this).tooltip({
+            html: true,
+            title: function() {
+                var tooltipId = $(this).data("tooltip");
+                return $("#" + tooltipId).html();
+            },
+            placement: 'right',
+            boundary: 'window',
+            container: 'body'
+        });
+    });
+}


### PR DESCRIPTION
\1. Mouseover próximo à lupa e o texto de status de atendimento (indi…car o local com um ponto de interrogação como [este](https://github.com/Transparencia-Brasil/achados-e-pedidos-site/blob/master/webroot/assets/images/pedidos/pergunta.png)) com o seguinte texto e redirecionamento para link (também no texto):

\2. Reordenamento da coluna à direita do pedido (ver figura abaixo), onde se vê os boxes "0 Seguidores > Avaliação > Encontrou algo errado"  reordenar para "Encontrou algo errado > Avaliação > 0 Seguidores"

\3. Remover a frase (status verificado) conforme imagem. Alguns status possuem essa frase e outros não, talvez esteja no banco de dados.